### PR TITLE
Updated Dockerfile + Automated Builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,3 +89,62 @@ jobs:
         file: ./artifacts/${{ env.RELEASE_BIN }}-${{ steps.vars.outputs.tag }}-${{ matrix.release_suffix }}
         asset_name: ${{ env.RELEASE_BIN }}-${{ steps.vars.outputs.tag }}-${{ matrix.release_suffix }}
         tag: ${{ github.ref }}
+
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Prepare
+        id: prep
+        run: |
+          DOCKER_IMAGE=${{ secrets.DOCKERHUB_USERNAME }}/git-mirror
+          VERSION=edge
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/v}
+          fi
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            VERSION=nightly
+          fi
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          if [[ $VERSION =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+            TAGS="$TAGS,${DOCKER_IMAGE}:latest"
+          fi
+          echo ::set-output name=tags::${TAGS}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.prep.outputs.tags }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM rust:stretch
+FROM rust:buster
 WORKDIR /usr/src/git-mirror
 COPY . .
-RUN cargo install
+RUN cargo install --path .
 
-FROM debian:stretch-backports
-RUN apt-get update && apt-get install -t stretch-backports -y git-core && rm -rf /var/lib/apt/lists/*
+FROM debian:buster
+RUN apt-get update && apt-get install -y git-core && rm -rf /var/lib/apt/lists/*
 WORKDIR /usr/local/bin
 COPY --from=0 /usr/local/cargo/bin/git-mirror .


### PR DESCRIPTION
This is mostly based on the example action here: https://github.com/metcalfc/docker-action-examples/blob/main/.github/workflows/release.yml because I've never touched them before and it seemed like the quickest starter.

You may wish to change line 102 in the actions definition to be bachp/git-mirror - I'm not sure whether the username idea will line up for you. 

You will need to create regular repository secrets on Github that align with a docker hub username and token that you create.

At the moment this is just doing x64 builds, I didn't spent much time trying other architectures.

Building the binary twice with rust seems very inefficient, but I'm not sure if there is an easy way of taking the linux binary and using it for the container build piece somehow.