### PR TITLE
chore: remove --all from git lfs fetch

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -116,9 +116,7 @@ impl GitWrapper for Git {
 
         if self.lfs_enabled {
             let mut lfs_fetch_cmd = self.git_base_cmd();
-            lfs_fetch_cmd
-                .args(["lfs", "fetch", "--all"])
-                .current_dir(repo_dir);
+            lfs_fetch_cmd.args(["lfs", "fetch"]).current_dir(repo_dir);
 
             self.run_cmd(lfs_fetch_cmd)
         } else {
@@ -144,9 +142,7 @@ impl GitWrapper for Git {
 
         if self.lfs_enabled {
             let mut lfs_fetch_cmd = self.git_base_cmd();
-            lfs_fetch_cmd
-                .args(["lfs", "fetch", "--all"])
-                .current_dir(repo_dir);
+            lfs_fetch_cmd.args(["lfs", "fetch"]).current_dir(repo_dir);
 
             self.run_cmd(lfs_fetch_cmd)
         } else {


### PR DESCRIPTION
The --all options fetches all the LFS objects from the default remote that are referenced by any commit in the main and develop branches, this is causing errors, so I suggest removing the flag, see also https://github.com/renovatebot/renovate/discussions/19373



