### PR TITLE
fix(git): override git lfs url in all cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.14.14] - 2025-06-19
+
+### Fixed
+
+- Override git lfs url in all cases when pushing to the destination, even when set via `.lfsconfig`
+
 ### Added
 
 ## [0.14.13] - 2025-01-24

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,7 +495,7 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "git-mirror"
-version = "0.14.13"
+version = "0.14.14"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-mirror"
-version = "0.14.13"
+version = "0.14.14"
 authors = ["Pascal Bach <pascal.bach@nextrem.ch>"]
 description = "Sync between different git repositories."
 license = "MIT"

--- a/src/git.rs
+++ b/src/git.rs
@@ -188,6 +188,8 @@ impl GitWrapper for Git {
 
         let mut push_cmd = self.git_base_cmd();
         push_cmd.current_dir(repo_dir);
+        // override the git lfs url when pushing, in case a .lfsconfig with a different URL exists
+        push_cmd.args(["-c", "lfs.url", dest]);
         push_cmd.args(["push", "-f"]);
         if let Some(r) = &refspec {
             push_cmd.arg(dest);


### PR DESCRIPTION
I was thinking of only doing this in cases that the `lfs.url` is actually overriden, but this would probably be slower than just setting the option in all cases.

Let me know what you think @bachp 

Closes https://github.com/bachp/git-mirror/issues/432

