### PR TITLE
feat(metrics): add dedicated timeout metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add a new `git_mirror_timeout` gauge metric to track how many projects run into a timeout.
+
 ## [0.14.16] - 2025-10-20
 
 ### Added


### PR DESCRIPTION
This PR introduces a new gauge metric `git_mirror_timeout` which tracks projects that encounter a `GitError::GitCommandTimeout` during the mirroring step. Projects that fail for other reasons continue to increment the existing `git_mirror_fail gauge`. These two gauges are mutually exclusive.