### PR TITLE
chore: fix typos in code and comments

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -13,7 +13,7 @@ use thiserror::Error;
 use log::debug;
 use wait_timeout::ChildExt;
 
-/// An error occuring during git command execution
+/// An error occurring during git command execution
 #[derive(Debug, Error)]
 pub enum GitError {
     #[error("Command {cmd_str} failed with system error: {err}")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ use slug::slugify;
 #[macro_use]
 extern crate serde_derive;
 
-// Used to allow multiple paralell sync tasks
+// Used to allow multiple parallel sync tasks
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 
 // Time handling
@@ -313,7 +313,7 @@ pub fn do_mirror(provider: Box<dyn Provider>, opts: &MirrorOptions) -> Result<()
         ))
     })?;
 
-    trace!("Aquired lockfile: {:?}", &lockfile);
+    trace!("Acquired lockfile: {:?}", &lockfile);
 
     // Get the list of repos to sync from gitlabsss
     let v = provider.get_mirror_repos().map_err(|e| -> GitMirrorError {
@@ -353,8 +353,8 @@ pub fn do_mirror(provider: Box<dyn Provider>, opts: &MirrorOptions) -> Result<()
 fn write_metrics(f: &Path) {
     let mut file = File::create(f).unwrap();
     let encoder = TextEncoder::new();
-    let metric_familys = prometheus::gather();
-    encoder.encode(&metric_familys, &mut file).unwrap();
+    let metric_families = prometheus::gather();
+    encoder.encode(&metric_families, &mut file).unwrap();
 }
 
 fn write_junit_report(f: &Path, ts: TestSuite) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,7 +179,7 @@ fn main() {
             info!("All done");
         }
         Err(e) => {
-            error!("Error occured: {e}");
+            error!("Error occurred: {e}");
             exit(e.into());
         }
     };

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -14,7 +14,7 @@ pub struct Mirror {
     pub lfs: bool,
 }
 
-/// An error occuring during mirror creation
+/// An error occurring during mirror creation
 #[derive(Debug, Error)]
 pub enum MirrorError {
     #[error("data store disconnected")]


### PR DESCRIPTION
Just some typos found by https://github.com/crate-ci/typos