### PR TITLE
ci: grant packages: write to docker job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,9 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,9 @@ jobs:
     name: Build and push Docker image
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
The GITHUB_TOKEN used by the docker job needs explicit packages: write permission to push images to ghcr.io. Without it, the push fails with 'denied: installation not allowed to Write organization package'.