### PR TITLE
chore: update flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1770169770,
-        "narHash": "sha256-awR8qIwJxJJiOmcEGgP2KUqYmHG4v/z8XpL9z8FnT1A=",
+        "lastModified": 1787964612,
+        "narHash": "sha256-0N9nghg3nwzX6b6qc77EzjR9cu/Z+UR66FlfsCqiURs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "aa290c9891fa4ebe88f8889e59633d20cc06a5f2",
+        "rev": "e8be7818e19ada32105a8af937a6a473b38167ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
I was facing some issues when trying to build git-mirror from the current flake.

It was specifically about crates.io giving 403 errors to nixpkgs derivations when fetching the sources. It was fixed in nixpkgs at some point https://github.com/NixOS/nixpkgs/pull/512735

Bumping the nixpkgs input fixes it.

```
nix flake update --commit-lock-file --refresh
```